### PR TITLE
Strip metadata fields and show exercise images

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,9 +34,6 @@
     </div>
 
     <div class="cmd-actions">
-      <button id="formatBtn" class="btn muted json-only" title="Prettify JSON">Format</button>
-      <button id="copyEntityBtn" class="btn muted json-only" title="Copy editor JSON">Copy editor JSON</button>
-      <button id="copyFullBtn" class="btn muted json-only" title="Copy full item (entity + stats)">Copy full JSON</button>
     <button id="promptBtn" class="btn gpt" title="Build GPT prompt">GPT Review</button>
     <button id="promptImgBtn" class="btn gpt" title="Build Image Prompt">GPT Image</button>
     <button id="saveBtn" class="btn" disabled title="Save changes">Save</button>
@@ -182,6 +179,7 @@
 
   <template id="itemTemplate">
     <div class="item" role="option" tabindex="0">
+      <img class="thumb" alt="" />
       <div class="name"></div>
       <div class="meta">
         <span class="pill usage"></span>

--- a/styles.css
+++ b/styles.css
@@ -229,6 +229,7 @@ main{
   padding: 8px 10px 10px;
   display: grid;
   gap: 10px;
+  align-content: start;
 }
 .item{
   background:var(--panel-2);
@@ -258,6 +259,7 @@ main{
 .item:hover{border-color:#2b394f; background:#13233a}
 .item.active{outline:2px solid rgba(119,182,255,.8)}
 .name{font-weight:800}
+.thumb{width:100%;height:auto;border-radius:8px;object-fit:cover}
 .meta{color:var(--muted); font-size:12px; display:flex; gap:10px; align-items:center}
 .pill{background:#0d213a; color:#c7e2ff; padding:2px 8px; border-radius:999px; font-size:12px; border:1px solid #15365d}
 


### PR DESCRIPTION
## Summary
- Drop createdAt/updatedAt from POST/PUT payloads
- Render image thumbnails for exercises with an imageUrl
- Keep list cards equal height and remove unused JSON helper buttons

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7dbb5a2048333aa82f086438f4099