### PR TITLE
Improve admin login and logout flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 <body>
   <!-- Header -->
   <header>
-    <button id="loadBtn" class="btn" title="Fetch list from API">Load list</button>
+    <button id="logoutBtn" class="btn" style="margin-left:auto;" title="Logout">Logout</button>
   </header>
 
   <!-- Login overlay -->
@@ -18,6 +18,7 @@
       <h2>Sign in</h2>
       <input id="loginEmail" type="email" placeholder="Email" required />
       <input id="loginPassword" type="password" placeholder="Password" required />
+      <div id="loginError" class="error" style="display:none"></div>
       <button id="loginBtn" class="btn" type="submit">Login</button>
     </form>
   </div>
@@ -25,6 +26,7 @@
   <!-- Command bar: sticky below header -->
   <div id="commandBar" class="command-bar">
     <input id="search" type="search" placeholder="Search by name…"/>
+    <button id="loadBtn" class="btn" title="Fetch list from API">Load list</button>
     <button id="newBtn" class="btn warn" title="Create new exercise example">New</button>
 
     <span class="spacer"></span>

--- a/styles.css
+++ b/styles.css
@@ -390,10 +390,16 @@ main > .sidebar .list{
   display:flex;
   flex-direction:column;
   gap:12px;
+  min-width:320px;
 }
 .login-form input{
-  padding:8px;
+  padding:12px;
   background:var(--field);
   border:1px solid var(--border);
   color:var(--text);
+  font-size:16px;
+}
+.login-form .error{
+  color:var(--danger);
+  font-size:14px;
 }


### PR DESCRIPTION
## Summary
- point login request to /auth/login and show errors inline
- enlarge login modal and add logout button
- automatically logout on 403 responses and relocate Load button next to New

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7e5ae8a5c83338518138f541e969e