### PR TITLE
Style login popup and buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,15 +9,21 @@
 <body>
   <!-- Header -->
   <header>
-    <button id="logoutBtn" class="btn" style="margin-left:auto;" title="Logout">Logout</button>
+    <button id="logoutBtn" class="btn danger" style="margin-left:auto;" title="Logout">Logout</button>
   </header>
 
   <!-- Login overlay -->
   <div id="loginOverlay" class="login-overlay" style="display:none;">
     <form id="loginForm" class="login-form">
       <h2>Sign in</h2>
-      <input id="loginEmail" type="email" placeholder="Email" required />
-      <input id="loginPassword" type="password" placeholder="Password" required />
+      <div class="field">
+        <label for="loginEmail">Email</label>
+        <input id="loginEmail" type="email" placeholder="Email" required />
+      </div>
+      <div class="field">
+        <label for="loginPassword">Password</label>
+        <input id="loginPassword" type="password" placeholder="Password" required />
+      </div>
       <div id="loginError" class="error" style="display:none"></div>
       <button id="loginBtn" class="btn" type="submit">Login</button>
     </form>
@@ -26,8 +32,8 @@
   <!-- Command bar: sticky below header -->
   <div id="commandBar" class="command-bar">
     <input id="search" type="search" placeholder="Search by name…"/>
-    <button id="loadBtn" class="btn" title="Fetch list from API">Load list</button>
     <button id="newBtn" class="btn warn" title="Create new exercise example">New</button>
+    <button id="loadBtn" class="btn" title="Fetch list from API">Load list</button>
 
     <span class="spacer"></span>
 

--- a/styles.css
+++ b/styles.css
@@ -179,6 +179,7 @@ input[type=number]{ -moz-appearance:textfield }
 .btn:hover{filter:brightness(1.05)}
 .btn.muted{background:var(--panel-2); color:var(--text); border:1px solid var(--border); box-shadow:none}
 .btn.warn{background:var(--warning); color:#111}
+.btn.danger{background:var(--danger); color:#fff}
 .btn.ghost{background:transparent; border:1px dashed var(--border)}
 .btn:disabled{opacity:.5; cursor:not-allowed}
 .btn:active{transform:translateY(1px)}
@@ -391,13 +392,6 @@ main > .sidebar .list{
   flex-direction:column;
   gap:12px;
   min-width:320px;
-}
-.login-form input{
-  padding:12px;
-  background:var(--field);
-  border:1px solid var(--border);
-  color:var(--text);
-  font-size:16px;
 }
 .login-form .error{
   color:var(--danger);


### PR DESCRIPTION
## Summary
- Match login popup fields to app-wide design
- Add red `Logout` button style
- Swap `Load list` and `New` buttons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7e96ca41c8333b235ac55bb75f82b