### PR TITLE
feat: improve mobile layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -191,6 +191,18 @@
     </section>
   </main>
 
+  <!-- Mobile floating action button -->
+  <div id="mobileFab" class="fab">
+    <div class="fab-menu">
+      <button id="fabNew" class="btn warn" title="Create new exercise example">New</button>
+      <button id="fabLoad" class="btn" title="Fetch list from API">Load list</button>
+      <button id="fabPrompt" class="btn gpt" title="Build GPT prompt">GPT Review</button>
+      <button id="fabPromptImg" class="btn gpt" title="Build Image Prompt">GPT Image</button>
+      <button id="fabSave" class="btn" disabled title="Save changes">Save</button>
+    </div>
+    <button id="fabToggle" class="btn fab-main" title="More actions">+</button>
+  </div>
+
   <template id="itemTemplate">
     <div class="item" role="option" tabindex="0">
       <img class="thumb" alt="" />

--- a/js/app.js
+++ b/js/app.js
@@ -150,6 +150,15 @@ function updateCommandBarVisibility(){
   toggle(viewToggle, active);
   toggle(els.jsonStatus, active);
 
+  // Sync mobile fab buttons
+  const fabPrompt = document.getElementById('fabPrompt');
+  const fabPromptImg = document.getElementById('fabPromptImg');
+  const fabSave = document.getElementById('fabSave');
+  toggle(fabPrompt, active);
+  toggle(fabPromptImg, active);
+  toggle(fabSave, active);
+  if (fabSave) fabSave.disabled = els.saveBtn.disabled;
+
   // Right column content
   if (!active){
     els.builder.classList.remove('show');
@@ -487,6 +496,7 @@ async function saveCurrent(){
   if (!ok){ toast({title:'Fix validation errors', type:'error'}); return; }
 
   els.saveBtn.disabled = true;
+  { const fabSave = document.getElementById('fabSave'); if (fabSave) fabSave.disabled = true; }
   try{
     if (isNew){
       // Create: DO NOT send id
@@ -545,10 +555,11 @@ async function saveCurrent(){
       renderList();
     }
   }catch(e){
-    toast({title:'Save failed', message:String(e.message||e), type:'error', ms:7000}); 
+    toast({title:'Save failed', message:String(e.message||e), type:'error', ms:7000});
     console.error(e);
   }finally{
     els.saveBtn.disabled = false;
+    { const fabSave = document.getElementById('fabSave'); if (fabSave) fabSave.disabled = false; }
   }
 }
 
@@ -601,6 +612,7 @@ function validateAll(){
   else if (warnings.length) setStatus('warn', warnings[0]);
   else setStatus('ok', 'Valid');
   els.saveBtn.disabled = !ok;
+  { const fabSave = document.getElementById('fabSave'); if (fabSave) fabSave.disabled = els.saveBtn.disabled; }
 
   if (!els.editor.hasAttribute('hidden')) els.editor.value = pretty(ent);
   return {ok, errors, warnings};
@@ -888,6 +900,7 @@ if (els.loginForm){
       validateAll();
     }catch{
       setStatus('bad','Invalid JSON'); els.saveBtn.disabled = true;
+      { const fabSave = document.getElementById('fabSave'); if (fabSave) fabSave.disabled = true; }
     }
   });
 
@@ -897,6 +910,19 @@ if (els.loginForm){
   els.builder.classList.remove('show');
   els.editor.hidden = true;
   document.body.classList.add('hide-json-controls');
+
+  // Floating action button for mobile
+  const fab = document.getElementById('mobileFab');
+  const fabToggle = document.getElementById('fabToggle');
+  if (fab && fabToggle) {
+    const closeFab = () => fab.classList.remove('open');
+    fabToggle.addEventListener('click', () => fab.classList.toggle('open'));
+    document.getElementById('fabNew').addEventListener('click', () => { els.newBtn.click(); closeFab(); });
+    document.getElementById('fabLoad').addEventListener('click', () => { els.load.click(); closeFab(); });
+    document.getElementById('fabPrompt').addEventListener('click', () => { els.promptBtn.click(); closeFab(); });
+    document.getElementById('fabPromptImg').addEventListener('click', () => { els.promptImgBtn.click(); closeFab(); });
+    document.getElementById('fabSave').addEventListener('click', () => { els.saveBtn.click(); closeFab(); });
+  }
 
   updateCommandBarVisibility(); // hide GPT/Save/toggle/status
   updateStickyOffsets();

--- a/styles.css
+++ b/styles.css
@@ -123,6 +123,9 @@ header{
 .command-bar .view-toggle{ flex-shrink:0; }
 .command-bar .cmd-actions{ display:flex; gap:8px; flex-shrink:0; }
 
+/* Floating action button (hidden by default) */
+.fab{display:none;}
+
 /* Inputs — dark */
 input[type="password"],input[type="text"],input[type="email"],input[type="search"],input[type="url"],input[type="number"],select,textarea{
   width:100%;
@@ -402,4 +405,57 @@ main > .sidebar .list{
 .login-form .error{
   color:var(--danger);
   font-size:14px;
+}
+/* Mobile adjustments */
+@media (max-width: 600px) {
+  main {
+    padding:8px;
+    gap:8px;
+  }
+  #commandBar {
+    padding:8px 10px;
+  }
+  #commandBar > *:not(#search) {
+    display:none;
+  }
+  #commandBar input[type="search"] {
+    flex:1 1 100%;
+    width:100%;
+    min-width:0;
+  }
+  .grid.two {
+    grid-template-columns:1fr;
+  }
+  .bundle-row {
+    grid-template-columns:1fr 1fr auto;
+  }
+
+  /* Floating action menu */
+  .fab {
+    display:flex;
+    position:fixed;
+    bottom:16px;
+    right:16px;
+    flex-direction:column;
+    align-items:flex-end;
+    gap:8px;
+    z-index:50;
+  }
+  .fab .fab-menu {
+    display:none;
+    flex-direction:column;
+    gap:8px;
+    margin-bottom:8px;
+  }
+  .fab.open .fab-menu { display:flex; }
+  .fab .fab-main {
+    width:56px;
+    height:56px;
+    border-radius:50%;
+    padding:0;
+    font-size:32px;
+    display:flex;
+    align-items:center;
+    justify-content:center;
+  }
 }


### PR DESCRIPTION
## Summary
- collapse command bar on phones to show only search field
- add floating action menu for prompt, save and related actions
- sync floating menu state with existing desktop buttons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7ee840e4483338bbe43d5a69b984d