### PR TITLE
Handle unauthorized responses by logging out

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1015,9 +1015,10 @@ if (els.loginForm){
   window.fetch = async (...args)=>{
     try{
       const resp = await orig(...args);
-      if(resp.status === 403){
+      if(resp.status === 401 || resp.status === 403){
         logout();
-        toast({title:'Session expired', type:'error'});
+        const message = resp.status === 401 ? 'Authorization has expired. Please log in again.' : 'Session expired';
+        toast({title:'Logged out', message, type:'error'});
       }
       return resp;
     }catch(e){


### PR DESCRIPTION
## Summary
- log users out when any API request responds with 401 or 403
- display a logout toast message and clear stored tokens on unauthorized responses

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cb11bda5bc83339efd2462bef4311f