### PR TITLE
Fix sort dropdown overlay to avoid command bar scrolling

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -264,10 +264,35 @@ function updateSortUI(){
   }
 }
 
+function positionSortMenu(){
+  if (!els.sortDropdown || !els.sortMenu || !els.sortToggle) return;
+  if (!els.sortDropdown.classList.contains('open')) return;
+
+  const menu = els.sortMenu;
+  const toggleRect = els.sortToggle.getBoundingClientRect();
+  const viewportWidth = document.documentElement.clientWidth || window.innerWidth || 0;
+  const gutter = 12;
+
+  // Force layout so width is measured correctly.
+  const menuWidth = menu.offsetWidth;
+
+  let left = toggleRect.right - menuWidth;
+  if (left < gutter) left = gutter;
+  if (left + menuWidth > viewportWidth - gutter) {
+    left = Math.max(gutter, viewportWidth - gutter - menuWidth);
+  }
+
+  const top = toggleRect.bottom + 8;
+
+  menu.style.left = `${left}px`;
+  menu.style.top = `${top}px`;
+}
+
 function openSortMenu(){
   if (!els.sortDropdown) return;
   els.sortDropdown.classList.add('open');
   if (els.sortToggle) els.sortToggle.setAttribute('aria-expanded', 'true');
+  positionSortMenu();
   if (els.sortMenu){
     const active = els.sortMenu.querySelector(`[data-sort="${currentSort}"]`);
     if (active) active.focus();
@@ -283,6 +308,10 @@ function closeSortMenu(){
     if (els.sortDropdown.contains(document.activeElement)) {
       els.sortToggle.focus();
     }
+  }
+  if (els.sortMenu) {
+    els.sortMenu.style.left = '';
+    els.sortMenu.style.top = '';
   }
 }
 
@@ -1035,6 +1064,14 @@ window.addEventListener('DOMContentLoaded', async ()=>{
       toggleSortMenu();
     });
   }
+  const commandBar = document.getElementById('commandBar');
+  if (commandBar) {
+    try {
+      commandBar.addEventListener('scroll', positionSortMenu, {passive:true});
+    } catch {
+      commandBar.addEventListener('scroll', positionSortMenu);
+    }
+  }
   if (els.sortMenu) {
     els.sortMenu.querySelectorAll('.dropdown-item').forEach(btn => {
       btn.addEventListener('click', () => {
@@ -1057,6 +1094,7 @@ window.addEventListener('DOMContentLoaded', async ()=>{
     if (els.sortDropdown.contains(evt.target)) return;
     closeSortMenu();
   });
+  window.addEventListener('resize', positionSortMenu);
   updateSortUI();
   els.newBtn.addEventListener('click', newItem);
   if (els.mobileBackBtn) {

--- a/styles.css
+++ b/styles.css
@@ -109,7 +109,9 @@ header{
   border-bottom:1px solid var(--border);
   box-shadow:0 6px 18px rgba(0,0,0,.22);
   white-space:nowrap;
-  overflow-x:auto; scrollbar-width:thin;
+  overflow-x:auto;
+  overflow-y:hidden;
+  scrollbar-width:thin;
 }
 .command-bar #currentId{
   max-width:28ch; overflow:hidden; text-overflow:ellipsis;
@@ -128,9 +130,9 @@ header{
 .command-bar .dropdown .chevron{ transition:transform .2s ease; font-size:12px; }
 .command-bar .dropdown.open .chevron{ transform:rotate(180deg); }
 .command-bar .dropdown-menu{
-  position:absolute;
-  top:calc(100% + 8px);
-  right:0;
+  position:fixed;
+  top:auto;
+  left:auto;
   display:none;
   flex-direction:column;
   gap:4px;
@@ -140,7 +142,9 @@ header{
   border:1px solid var(--border);
   border-radius:14px;
   box-shadow:var(--shadow);
-  z-index:30;
+  z-index:90;
+  max-height:70vh;
+  overflow-y:auto;
 }
 .command-bar .dropdown.open .dropdown-menu{ display:flex; }
 .command-bar .dropdown-item{


### PR DESCRIPTION
## Summary
- stop the command bar from creating a vertical scrollbar while keeping horizontal scrolling
- render the sort dropdown menu as a fixed overlay and dynamically place it relative to the toggle button

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e18e5a07708333b895f755c8c7c3d1