### PR TITLE
Add sort option for exercises missing images

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,6 +43,7 @@
         <button type="button" class="dropdown-item" data-sort="name" role="menuitemradio" aria-checked="true">Имя</button>
         <button type="button" class="dropdown-item" data-sort="createdAt" role="menuitemradio" aria-checked="false">Дата создания</button>
         <button type="button" class="dropdown-item" data-sort="hasImage" role="menuitemradio" aria-checked="false">Наличие картинки</button>
+        <button type="button" class="dropdown-item" data-sort="missingImage" role="menuitemradio" aria-checked="false">Отсутствие картинки</button>
       </div>
     </div>
     <button id="newBtn" class="btn warn" title="Create new exercise example">New</button>

--- a/js/app.js
+++ b/js/app.js
@@ -189,6 +189,13 @@ const SORT_OPTIONS = {
       const diff = Number(itemHasImage(b)) - Number(itemHasImage(a));
       return diff !== 0 ? diff : compareByName(a, b);
     }
+  },
+  missingImage: {
+    label: 'Отсутствие картинки',
+    compare: (a, b) => {
+      const diff = Number(!itemHasImage(b)) - Number(!itemHasImage(a));
+      return diff !== 0 ? diff : compareByName(a, b);
+    }
   }
 };
 


### PR DESCRIPTION
## Summary
- add a sorting preset that prioritizes exercises without images
- expose the new option in the sort dropdown UI

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e24707c7cc83339f44be29af71ca00